### PR TITLE
[Core] Unescape query if decodeURIComponent fail

### DIFF
--- a/libs/core.js
+++ b/libs/core.js
@@ -38,7 +38,14 @@ Tagtoo.Core = {
             var vs = parts[i].split('=');
             if (vs.length == 2) {
                 var key = decodeURIComponent(vs[0]);
-                var value = decodeURIComponent(vs[1]);
+                try {
+                    var value = decodeURIComponent(vs[1]);
+                } catch(e) {
+                    if (e.name === 'URIError')
+                        var value = unescape(vs[1]);
+                    else
+                        throw e;
+                }
                 data[key] = value;
             }
         }


### PR DESCRIPTION
When searching in website of Carrefour, chinese will not deal with
encodeURIComponent but escape.